### PR TITLE
Fixed link on Riot Medicine PDF

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -216,7 +216,10 @@ _Attending a protest can be prohibitive for many reasons, including risk profile
 ## Additional Resources
 
 ### Medicine 
-https://riotmedicine.net/static/downloads/riot-medicine.pdf
+
+https://riotmedicine.net/static/downloads/riot-medicine-en.pdf
+
+https://riotmedicine.net/static/downloads/riot-medicine-field-guide.pdf
 
 ### Filming
 


### PR DESCRIPTION
The original link was not working (too many redirects). Added the link to the full book and to the field guide.